### PR TITLE
Hotfix/mapper004 irq

### DIFF
--- a/src/cpu/unofficial_opcodes.rs
+++ b/src/cpu/unofficial_opcodes.rs
@@ -47,6 +47,6 @@ pub fn stp(cpu: &mut Cpu6502) -> u8 {
 
 /// This is used when it is an illegal opcode and does nothing
 pub fn xxx(cpu: &mut Cpu6502) -> u8 {
-    // println!("Unofficial opcode 0x{:02X}", cpu.opcode);
+    println!("Unofficial opcode 0x{:02X}", cpu.opcode);
     0
 }

--- a/src/mappers/mapper001/mod.rs
+++ b/src/mappers/mapper001/mod.rs
@@ -38,13 +38,21 @@ pub struct Mapper001 {
 }
 
 impl Mapper001 {
-    pub fn new(prg_banks: u8, chr_banks: u8, battery_backed_ram: bool) -> Self {
+    pub fn new(prg_banks: u8, chr_banks: u8, battery_backed_ram: bool, mirror: Mirror) -> Self {
+        let control_mirror = match mirror {
+            Mirror::OneScreenLow => 0,
+            Mirror::OneScreenHigh => 1,
+            Mirror::Vertical => 2,
+            Mirror::Horizontal => 3,
+            _ => panic!("Invalid mirror mode")
+        };
+
         Mapper001 {
             prg_banks,
             chr_banks,
             battery_backed_ram,
             chr_bank: chr_bank::ChrBank::new(),
-            control_register: control_register::ControlRegister(0x00),
+            control_register: control_register::ControlRegister(control_mirror),
             prg_bank: prg_bank::PrgBank::new(prg_banks),
             ram: vec![0; KILOBYTES_32 as usize],
             shift_register: Default::default()

--- a/src/mappers/mapper004/bank_select.rs
+++ b/src/mappers/mapper004/bank_select.rs
@@ -62,9 +62,9 @@ impl BankSelect {
         match self.chr_inversion {
             ChrA12Inversion::LowerTwo2KilobyteBanks => {
                 self.chr_banks[0] = (self.bank_registers[0] & ignore_bottom_bit) * chr_offset;
-                self.chr_banks[1] = (self.bank_registers[0] * chr_offset) + chr_offset;
+                self.chr_banks[1] = ((self.bank_registers[0] & ignore_bottom_bit) * chr_offset) + chr_offset;
                 self.chr_banks[2] = (self.bank_registers[1] & ignore_bottom_bit) * chr_offset;
-                self.chr_banks[3] = (self.bank_registers[1] * chr_offset) + chr_offset;
+                self.chr_banks[3] = ((self.bank_registers[1] & ignore_bottom_bit) * chr_offset) + chr_offset;
                 self.chr_banks[4] = self.bank_registers[2] * chr_offset;
                 self.chr_banks[5] = self.bank_registers[3] * chr_offset;
                 self.chr_banks[6] = self.bank_registers[4] * chr_offset;
@@ -76,9 +76,9 @@ impl BankSelect {
                 self.chr_banks[2] = self.bank_registers[4] * chr_offset;
                 self.chr_banks[3] = self.bank_registers[5] * chr_offset;
                 self.chr_banks[4] = (self.bank_registers[0] & ignore_bottom_bit) * chr_offset;
-                self.chr_banks[5] = (self.bank_registers[0] * chr_offset) + chr_offset;
+                self.chr_banks[5] = ((self.bank_registers[0] & ignore_bottom_bit) * chr_offset) + chr_offset;
                 self.chr_banks[6] = (self.bank_registers[1] & ignore_bottom_bit) * chr_offset;
-                self.chr_banks[7] = (self.bank_registers[1] * chr_offset) + chr_offset;
+                self.chr_banks[7] = ((self.bank_registers[1] & ignore_bottom_bit) * chr_offset) + chr_offset;
             }
         }
     }

--- a/src/mappers/mapper004/mod.rs
+++ b/src/mappers/mapper004/mod.rs
@@ -27,14 +27,14 @@ pub struct Mapper004 {
 }
 
 impl Mapper004 {
-    pub fn new(prg_banks: u8, chr_banks: u8, battery_backed_ram: bool) -> Self {
+    pub fn new(prg_banks: u8, chr_banks: u8, battery_backed_ram: bool, mirror: Mirror) -> Self {
         Mapper004 {
             prg_banks,
             chr_banks,
             bank_select: bank_select::BankSelect::new(prg_banks),
             battery_backed_ram,
             interrupt_request: interrupt_request::InterruptRequest::new(),
-            mirror: Mirror::Horizontal,
+            mirror,
             prg_ram_protect: prg_ram_protect::PrgRamProtect::new(),
             ram: vec![0; KILOBYTES_8 as usize]
         }
@@ -56,7 +56,6 @@ impl Mapper004 {
 
 impl Mapper for Mapper004 {
     fn reset(&mut self) {
-        self.mirror = Mirror::Horizontal;
         self.bank_select.reset();
         self.interrupt_request.reset();
     }

--- a/src/ppu/mod.rs
+++ b/src/ppu/mod.rs
@@ -131,11 +131,11 @@ impl Ppu2C02 {
     }
 
     /// Read from the PPU Bus
-    fn ppu_read(&mut self, address: u16) -> u8 {
+    fn ppu_read(&self, address: u16) -> u8 {
         let mut data: u8 = 0;
         let ppu_address = address & PPU_ADDRESS_END;
 
-        if let Some(ref mut c) = self.cartridge {
+        if let Some(ref c) = self.cartridge {
             if c.borrow_mut().ppu_read(ppu_address, &mut data) {
                 return data;
             }
@@ -374,7 +374,7 @@ impl Ppu2C02 {
         }
     }
 
-    fn get_color_from_palette(&mut self, palette_id: u16, pixel_id: u16) -> colors::Color {
+    pub fn get_color_from_palette(&self, palette_id: u16, pixel_id: u16) -> colors::Color {
         let address = PALETTE_ADDRESS_LOWER + (palette_id * 4) + pixel_id;
         let color_index = self.ppu_read(address) & 0x3F; // Make sure we don't go out of bounds
         colors::COLOR_RAM[color_index as usize]

--- a/src/ppu/name_table.rs
+++ b/src/ppu/name_table.rs
@@ -22,7 +22,7 @@ impl NameTable {
         }
     }
     
-    pub fn read_data(&mut self, address: u16, cartridge: &Option<Rc<RefCell<Cartridge>>>) -> u8 {
+    pub fn read_data(&self, address: u16, cartridge: &Option<Rc<RefCell<Cartridge>>>) -> u8 {
         let name_table_address = NameTableAddress::new(address);
         match cartridge {
             Some(ref c) => {

--- a/src/ppu/palette_table.rs
+++ b/src/ppu/palette_table.rs
@@ -20,7 +20,6 @@ impl PaletteTable {
 
     pub fn write_data(&mut self, address: u16, data: u8) {
         let masked_address = PaletteTable::get_masked_address(address);
-        // println!("Palette write: {}",masked_address);
         self.data[masked_address as usize] = data;
     }
 


### PR DESCRIPTION
Fix an issue with default mirroring of the mapper for Mapper001 and Mapper004.

Slightly fixed the IRQ issue of Mapper004